### PR TITLE
fix: repeat copy does not copy correctly

### DIFF
--- a/lua/remote-nvim/providers/ssh/ssh_provider.lua
+++ b/lua/remote-nvim/providers/ssh/ssh_provider.lua
@@ -271,7 +271,7 @@ function NeovimSSHProvider:handle_neovim_config_update_on_remote()
   if should_copy_config then
     self:upload(
       self.local_nvim_user_config_path,
-      self.remote_neovim_config_path,
+      self.remote_xdg_config_path,
       "Copying local config onto remote machine..."
     )
   end


### PR DESCRIPTION
Copying the user config the second time, copies it inside the neovim config folder instead of overwriting it. This is primarily due to how the recursive copy works.