### PR TITLE
fix: handle when ui.select is synchronous

### DIFF
--- a/lua/remote-nvim/providers/ssh/ssh_provider.lua
+++ b/lua/remote-nvim/providers/ssh/ssh_provider.lua
@@ -456,17 +456,19 @@ end
 ---@see vim.ui.select
 function NeovimSSHProvider:get_user_selection(choices, input_opts, cb)
   local co = coroutine.running()
+  local select_choice_made = false
   vim.ui.select(choices, input_opts, function(choice)
-    cb(choice)
+    select_choice_made = true
     if choice == nil then
       self.notifier:stop("Setup cancelled", "warn")
       return
     end
+    cb(choice)
     if co then
       coroutine.resume(co)
     end
   end)
-  if co then
+  if co and not select_choice_made then
     coroutine.yield()
   end
 end


### PR DESCRIPTION
The default implementation of the vim.ui.select interface is to call inputlist() which is synchronous by nature. The previous selection implementation in the plugin assumed that the implementation is async. We support both synchronous and async implementations now although they would have a bit of a lag.

Closes #37.