### PR TITLE
fix: determine user's home directory on remote robustly

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,6 @@ These are the default values. Alter them as needed for your personal use.
   -- It should accept the same inputs as the packaged install script though)
   neovim_install_script_path = util.path_join(util.is_windows,
   util.get_package_root(), "scripts", "neovim_install.sh"),
-  -- Where should everything that Remote Neovim does on remote be stored. By
-  -- default, it stores everything inside ~/.remote-nvim so as long as you
-  -- delete that folder, you essentially wipe out everything that remote-nvim
-  -- has over there.
-  remote_neovim_install_home = util.path_join(util.is_windows, "~", ".remote-nvim"),
   -- Where is your personal Neovim config stored?
   neovim_user_config_path = vim.fn.stdpath("config"),
   local_client_config = {
@@ -167,9 +162,11 @@ These are the default values. Alter them as needed for your personal use.
       },
     },
   },
-
 }
 ```
+
+On remote, the installation happens inside the `.remote-nvim` folder in the user's
+home directory.
 
 ## 📌 Usage
 

--- a/doc/remote-nvim.txt
+++ b/doc/remote-nvim.txt
@@ -157,11 +157,6 @@ These are the default values. Alter them as needed for your personal use.
       -- It should accept the same inputs as the packaged install script though)
       neovim_install_script_path = util.path_join(util.is_windows,
       util.get_package_root(), "scripts", "neovim_install.sh"),
-      -- Where should everything that Remote Neovim does on remote be stored. By
-      -- default, it stores everything inside ~/.remote-nvim so as long as you
-      -- delete that folder, you essentially wipe out everything that remote-nvim
-      -- has over there.
-      remote_neovim_install_home = util.path_join(util.is_windows, "~", ".remote-nvim"),
       -- Where is your personal Neovim config stored?
       neovim_user_config_path = vim.fn.stdpath("config"),
       local_client_config = {
@@ -192,9 +187,11 @@ These are the default values. Alter them as needed for your personal use.
           },
         },
       },
-    
     }
 <
+
+On remote, the installation happens inside the `.remote-nvim` folder in the
+user’s home directory.
 
 
 USAGE                                                      *remote-nvim-usage*

--- a/lua/remote-nvim/init.lua
+++ b/lua/remote-nvim/init.lua
@@ -35,7 +35,6 @@ local utils = require("remote-nvim.utils")
 ---@class remote-nvim.config.PluginConfig
 ---@field ssh_config remote-nvim.config.PluginConfig.SSHConfig SSH configuration
 ---@field neovim_install_script_path string Local path where neovim installation script is stored
----@field remote_neovim_install_home string Where should remote neovim install and save configurations on the remote server
 ---@field neovim_user_config_path string Local path where the neovim configuration to be copied over to the remote
 --server is stored. This is assumed to be a directory and entire directory would be copied over
 ---@field local_client_config remote-nvim.config.RemoteConfig.LocalClientConfig Configuration for the local client
@@ -67,7 +66,6 @@ M.default_opts = {
     "scripts",
     "neovim_install.sh"
   ),
-  remote_neovim_install_home = utils.path_join(utils.is_windows, "~", ".remote-nvim"),
   neovim_user_config_path = vim.fn.stdpath("config"),
   local_client_config = {
     callback = function(port, _)

--- a/lua/remote-nvim/providers/executor.lua
+++ b/lua/remote-nvim/providers/executor.lua
@@ -8,10 +8,10 @@ local Executor = require("remote-nvim.middleclass")("Executor")
 
 ---Initialize executor instance
 ---@param host string Host name
----@param conn_opts string Connection options (passed when connecting)
+---@param conn_opts? string Connection options (passed when connecting)
 function Executor:init(host, conn_opts)
   self.host = host
-  self.conn_opts = conn_opts
+  self.conn_opts = conn_opts or ""
 
   self._job_id = nil
   self._job_exit_code = nil

--- a/lua/remote-nvim/providers/ssh/ssh_provider.lua
+++ b/lua/remote-nvim/providers/ssh/ssh_provider.lua
@@ -1,7 +1,5 @@
 ---@class remote-nvim.providers.ssh.SSHProvider: remote-nvim.providers.Provider
 ---@field super remote-nvim.providers.Provider
----@field host string Name of the host
----@field conn_opts string Connection options
 local SSHProvider = require("remote-nvim.providers.provider"):subclass("SSHProvider")
 
 local Notifier = require("remote-nvim.providers.notifier")

--- a/tests/remote-nvim/providers/provider_spec.lua
+++ b/tests/remote-nvim/providers/provider_spec.lua
@@ -54,7 +54,7 @@ describe("Provider", function()
         provider = "local",
         host = provider.host,
         connection_options = provider.conn_opts,
-        remote_neovim_home = remote_nvim.config.remote_neovim_install_home,
+        remote_neovim_home = ".remote-nvim",
         config_copy = nil,
         client_auto_start = nil,
         workspace_id = workspace_id,
@@ -78,7 +78,7 @@ describe("Provider", function()
         provider = "local",
         host = provider.host,
         connection_options = provider.conn_opts,
-        remote_neovim_home = remote_nvim.config.remote_neovim_install_home,
+        remote_neovim_home = provider._remote_neovim_home,
         config_copy = nil,
         client_auto_start = nil,
         workspace_id = workspace_id,
@@ -109,7 +109,7 @@ describe("Provider", function()
 
     it("by correctly setting workspace variables", function()
       provider:_setup_workspace_variables()
-      local remote_home = remote_nvim.config.remote_neovim_install_home
+      local remote_home = provider._remote_neovim_home
 
       assert.equals(provider._remote_os, "Linux")
       assert.equals(provider._remote_is_windows, false)
@@ -200,7 +200,7 @@ describe("Provider", function()
         provider = provider.provider_type,
         host = provider.host,
         connection_options = provider.conn_opts,
-        remote_neovim_home = remote_nvim.config.remote_neovim_install_home,
+        remote_neovim_home = ".remote-nvim",
         config_copy = nil,
         client_auto_start = nil,
         workspace_id = "ajdfkafd",
@@ -270,7 +270,7 @@ describe("Provider", function()
         provider = provider.provider_type,
         host = provider.host,
         connection_options = provider.conn_opts,
-        remote_neovim_home = remote_nvim.config.remote_neovim_install_home,
+        remote_neovim_home = ".remote-nvim",
         config_copy = nil,
         client_auto_start = nil,
         workspace_id = "ajdfkafd",
@@ -290,7 +290,7 @@ describe("Provider", function()
       provider:clean_up_remote_host()
       assert.stub(run_command_stub).was.called_with(
         match.is_ref(provider),
-        "rm -rf ~/.remote-nvim/workspaces/ajdfkafd",
+        ("rm -rf %s"):format(provider._remote_workspace_id_path),
         "Delete remote nvim workspace from remote host"
       )
       assert.are.same(provider._config_provider:get_workspace_config(provider.unique_host_id), {})
@@ -300,9 +300,11 @@ describe("Provider", function()
       selection_stub.returns("Delete remote neovim from remote host (Nuke it!)")
 
       provider:clean_up_remote_host()
-      assert
-        .stub(run_command_stub).was
-        .called_with(match.is_ref(provider), "rm -rf ~/.remote-nvim", "Delete remote nvim from remote host")
+      assert.stub(run_command_stub).was.called_with(
+        match.is_ref(provider),
+        ("rm -rf %s"):format(provider._remote_neovim_home),
+        "Delete remote nvim from remote host"
+      )
       assert.are.same(provider._config_provider:get_workspace_config(provider.unique_host_id), {})
     end)
   end)
@@ -545,7 +547,7 @@ describe("Provider", function()
         provider = provider.provider_type,
         host = provider.host,
         connection_options = provider.conn_opts,
-        remote_neovim_home = remote_nvim.config.remote_neovim_install_home,
+        remote_neovim_home = ".remote-nvim",
         config_copy = nil,
         client_auto_start = nil,
         workspace_id = "ajdfkafd",
@@ -611,7 +613,7 @@ describe("Provider", function()
         provider = provider.provider_type,
         host = provider.host,
         connection_options = provider.conn_opts,
-        remote_neovim_home = remote_nvim.config.remote_neovim_install_home,
+        remote_neovim_home = ".remote-nvim",
         config_copy = nil,
         client_auto_start = nil,
         workspace_id = "ajdfkafd",


### PR DESCRIPTION
We used to hardcode `~` to denote the home directory and hoped that would get resolved on the remote host. This lead to issues during docker support as `~` could not be resolved correctly in all cases (or maybe I did not know how to do it correctly with the correct shell escaping). But nonetheless, we have now relaxed this consideration and now determine the remote home dynamically during each new host's first setup run. This is done by running `echo $HOME` against the remote host and parsing the response to get the path. This path is saved as part of the configuration (same as earlier) and re-used during later runs.