### PR TITLE
fix(provider): Fix hostname parsing in connection options

### DIFF
--- a/tests/remote-nvim/providers/ssh/ssh_provider_spec.lua
+++ b/tests/remote-nvim/providers/ssh/ssh_provider_spec.lua
@@ -15,8 +15,14 @@ describe("SSH Provider", function()
     local ssh_provider = SSHProvider("localhost", "localhost -p 3011")
     assert.equals(ssh_provider.conn_opts, "-p 3011")
 
-    ssh_provider = SSHProvider("localhost", " localhost ")
+    ssh_provider = SSHProvider("localhost", " localhost")
     assert.equals(ssh_provider.conn_opts, "")
+
+    ssh_provider = SSHProvider("localhost", "localhost ")
+    assert.equals(ssh_provider.conn_opts, "")
+
+    ssh_provider = SSHProvider("user@localhost", "user@localhost")
+    assert.equals("", ssh_provider.conn_opts)
   end)
 
   it("should remove '-N' ssh option from connection options (if present)", function()


### PR DESCRIPTION
We were not parsing connection options correctly for hostname which needs to be removed from connection string. We have now implemented a more robust mechanism for handling this instead of relying on regular expressions.

Fixes #63.