### PR TITLE
Support for symlink/building Neovim

### DIFF
--- a/.github/workflows/installation_test.yml
+++ b/.github/workflows/installation_test.yml
@@ -13,18 +13,71 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
-  install_test:
-    name: Test Neovim install
+  install_linux:
+    name: Test official release install on Linux
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
-    runs-on: ${{ matrix.os }}-latest
+        install_method: [binary, source]
+        neovim_version: [stable, nightly, v0.9.0]
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install Neovim (stable) on ${{ matrix.os }}
+      - uses: actions/checkout@v4
+      - name: Install build pre-requisites
+        run: |
+          sudo apt-get install -y ninja-build gettext \
+          cmake unzip curl build-essential
+      - name: Install Neovim
         shell: bash
         run: |-
           chmod +x ./scripts/neovim_install.sh ./scripts/neovim_download.sh
-          ./scripts/neovim_install.sh -v stable -d ~/.remote-nvim
-          ~/.remote-nvim/nvim-downloads/stable/bin/nvim -v
+          ./scripts/neovim_install.sh -v ${{ matrix.neovim_version }} \
+          -d ~/.remote-nvim \
+          -m ${{ matrix.install_method }} -a x86_64
+          ~/.remote-nvim/nvim-downloads/${{ matrix.neovim_version }}/bin/nvim -v
+  install_macos:
+    name: Test official release install on macOS
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {instance: macos-latest, arch: x86_64}
+          - {instance: macos-14, arch: arm64}
+        install_method: [binary, source]
+        neovim_version: [stable, nightly, v0.9.0]
+    runs-on: ${{ matrix.config.instance }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Neovim
+        shell: bash
+        run: |-
+          chmod +x ./scripts/neovim_install.sh ./scripts/neovim_download.sh
+          ./scripts/neovim_install.sh -v ${{ matrix.neovim_version }} \
+          -d ~/.remote-nvim \
+          -m ${{ matrix.install_method }} -a ${{ matrix.config.arch }}
+          ~/.remote-nvim/nvim-downloads/${{ matrix.neovim_version }}/bin/nvim -v
+  symlink_test:
+    name: Test symlink to system Neovim works
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {instance: ubuntu-latest, arch: x86_64}
+          - {instance: macos-latest, arch: x86_64}
+          - {instance: macos-14, arch: arm64}
+        neovim_version: [stable, nightly, v0.9.0]
+    runs-on: ${{ matrix.config.instance }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/action-setup-vim@v1
+        name: Install Neovim
+        with:
+          neovim: true
+          version: ${{ matrix.neovim_version }}
+      - name: Symlink Neovim to system neovim install
+        shell: bash
+        run: |-
+          chmod +x ./scripts/neovim_install.sh ./scripts/neovim_download.sh
+          ./scripts/neovim_install.sh -v system -d ~/.remote-nvim -m system \
+           -a ${{ matrix.config.arch }}
+          ~/.remote-nvim/nvim-downloads/system/bin/nvim -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_install_hook_types: [pre-commit]
 default_stages: [pre-commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-json
       - id: check-toml
@@ -17,35 +17,35 @@ repos:
       - id: pretty-format-json
         args: [--autofix]
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.7.0-1
+    rev: v3.8.0-1
     hooks:
       - id: shfmt  # native (requires/installs Go to build)
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.9.0
+    rev: v0.10.0
     hooks:
       - id: shellcheck
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.36.0
+    rev: v0.39.0
     hooks:
       - id: markdownlint-fix
         exclude: CHANGELOG.md
       - id: markdownlint
         exclude: CHANGELOG.md
   - repo: https://github.com/JohnnyMorganz/StyLua
-    rev: v0.18.2
+    rev: v0.20.0
     hooks:
       - id: stylua
   - repo: https://github.com/lyz-code/yamlfix/
-    rev: 1.13.0
+    rev: 1.16.0
     hooks:
       - id: yamlfix
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.32.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
         args: [--strict]
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 3.9.0
+    rev: v3.24.0
     hooks:
       - id: commitizen
   - repo: https://github.com/amitds1997/selene

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ you have an alternative though, I would be happy to integrate it into the plugin
 
 - **Offline mode** - If the remote does not have access to GitHub, Neovim release can be locally
   downloaded and then transferred to the remote. For more details, see [Offline mode](#-offline-mode).
+- **Building from source/Use globally installed Neovim** - If Neovim is not available for your OS/Arch, you can
+  build it from source and/or symlink to the globally available Neovim.
 
 ### Planned features
 
@@ -52,7 +54,7 @@ you have an alternative though, I would be happy to integrate it into the plugin
 
 | Support level                     | OS                                                                      |
 | --------------------------------- | ----------------------------------------------------------------------- |
-| ✅ **Supported**                   | Linux, MacOS                                                            |
+| ✅ **Supported**                   | Linux, MacOS, FreeBSD (using build from source and/or globally available Neovim)|
 | 🚧 **In progress**                 | FreeBSD ([#71](https://github.com/amitds1997/remote-nvim.nvim/pull/71)) |
 | 🟡 **Planned but not implemented** | Windows, WSL                                                            |
 
@@ -357,12 +359,14 @@ you have the correct path to the script. Adjust script path as per where the plu
 Alternatively, you can also clone the repo at a separate location and run this script from inside the cloned repo.
 
 ```bash
-./scripts/neovim_download.sh -v <version> -d <cache-dir> -o <os-type>
+./scripts/neovim_download.sh -v <version> -d <cache-dir> -o <os-type> -a <arch-type> -t <release-type>
 
 # <version> can be stable, nightly or any Neovim release provided like v0.9.4
 # <cache-dir> is the path in which the Neovim release and it's checksum should be downloaded. This should be same as the cache_dir plugin configuration value else it won't be
 # detected by the plugin. See configuration below.
 # <os-type> specifies which OS's binaries should be downloaded. Supported values are "Linux" and "macOS"
+# <arch-type> is the host's architecture. Can be `x86_64` or `arm64`
+# <release-type> is type of release to download. Can be `binary` or `source`
 ```
 
 To enable this,

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,5 @@
 ## Backlog
 
 1. Use `plenary.async`
+2. Add CI runs for the complete workflow run in Ubuntu, MacOS Intel, MacOS M1
+3. Create single form for everything

--- a/doc/remote-nvim.txt
+++ b/doc/remote-nvim.txt
@@ -31,12 +31,12 @@ FEATURES                                                *remote-nvim-features*
   Remote mode         Current support
   ------------------- ---------------------------------------------------
   SSH (using          Fully supported
-  password)
+  password)           
 
   SSH(using SSH key)  Fully supported
 
   SSH(using           Fully supported
-  ssh_config file)
+  ssh_config file)    
 
   Dockerimage         In progress (66)
 
@@ -53,6 +53,8 @@ IMPLEMENTED FEATURES ~
 
 - **Offline mode** - If the remote does not have access to GitHub, Neovim release can be locally
     downloaded and then transferred to the remote. For more details, see |remote-nvim-offline-mode|.
+- **Building from source/Use globally installed Neovim** - If Neovim is not available for your OS/Arch, you can
+    build it from source and/or symlink to the globally available Neovim.
 
 
 PLANNED FEATURES ~
@@ -80,12 +82,13 @@ OS SUPPORT ~
   -----------------------------------------------------------------------
   Support level          OS
   ---------------------- ------------------------------------------------
-  Supported              Linux, MacOS
+  Supported              Linux, MacOS, FreeBSD (using build from source
+                         and/or globally available Neovim)
 
   In progress            FreeBSD (71)
 
   Planned but not        Windows, WSL
-  implemented
+  implemented            
   -----------------------------------------------------------------------
 
 LOCAL MACHINE  ~
@@ -145,7 +148,7 @@ changing the value.
         ssh_binary = "ssh", -- Binary to use for running SSH command
         scp_binary = "scp", -- Binary to use for running SSH copy commands
         ssh_config_file_paths = { "$HOME/.ssh/config" }, -- Which files should be considered to contain the ssh host configurations. NOTE: `Include` is respected in the provided files.
-
+    
         -- These are useful for password-based SSH authentication.
         -- It provides parsing pattern for the plugin to detect that an input is requested.
         -- Each element contains the following attributes:
@@ -169,7 +172,7 @@ changing the value.
           },
         },
       },
-
+    
       -- Path to the script that would be copied to the remote and called to ensure that neovim gets installed.
       -- Default path is to the plugin's own ./scripts/neovim_install.sh file.
       neovim_install_script_path = utils.path_join(
@@ -178,15 +181,15 @@ changing the value.
         "scripts",
         "neovim_install.sh"
       ),
-
+    
       -- Modify the UI for the plugin's progress viewer.
       -- type can be "split" or "popup". All options from https://github.com/MunifTanjim/nui.nvim/tree/main/lua/nui/popup and https://github.com/MunifTanjim/nui.nvim/tree/main/lua/nui/split are supported.
       -- Note that some options like "border" are only available for "popup".
       progress_view = {
         type = "popup",
       },
-
-
+    
+    
       -- Offline mode configuration. For more details, see the "Offline mode" section below.
       offline_mode = {
         -- Should offline mode be enabled?
@@ -196,7 +199,7 @@ changing the value.
         -- What path should be looked at to find locally available releases
         cache_dir = utils.path_join(utils.is_windows, vim.fn.stdpath("cache"), constants.PLUGIN_NAME, "version_cache"),
       },
-
+    
       -- Remote configuration
       remote = {
         -- List of directories that should be copied over
@@ -237,7 +240,7 @@ changing the value.
           },
         },
       },
-
+    
       -- You can supply your own callback that should be called to create the local client. This is the default implementation.
       -- Two arguments are passed to the callback:
       -- port: Local port at which the remote server is available
@@ -250,7 +253,7 @@ changing the value.
           end
         end)
       end,
-
+    
       -- Plugin log related configuration [PREFER NOT TO CHANGE THIS]
       log = {
         -- Where is the log file
@@ -398,7 +401,7 @@ run this script from inside the cloned repo.
 
 >bash
     ./scripts/neovim_download.sh -v <version> -d <cache-dir> -o <os-type> -a <arch-type> -t <release-type>
-
+    
      <version> can be stable, nightly or any Neovim release provided like v0.9.4
      <cache-dir> is the path in which the Neovim release and it's checksum should be downloaded. This should be same as the cache_dir plugin configuration value else it won't be
      detected by the plugin. See configuration below.

--- a/doc/remote-nvim.txt
+++ b/doc/remote-nvim.txt
@@ -1,4 +1,4 @@
-*remote-nvim.txt*       For Neovim >= 0.9.0      Last change: 2024 February 14
+*remote-nvim.txt*        For Neovim >= 0.9.0        Last change: 2024 April 25
 
 ==============================================================================
 Table of Contents                              *remote-nvim-table-of-contents*
@@ -31,12 +31,12 @@ FEATURES                                                *remote-nvim-features*
   Remote mode         Current support
   ------------------- ---------------------------------------------------
   SSH (using          Fully supported
-  password)           
+  password)
 
   SSH(using SSH key)  Fully supported
 
   SSH(using           Fully supported
-  ssh_config file)    
+  ssh_config file)
 
   Dockerimage         In progress (66)
 
@@ -85,7 +85,7 @@ OS SUPPORT ~
   In progress            FreeBSD (71)
 
   Planned but not        Windows, WSL
-  implemented            
+  implemented
   -----------------------------------------------------------------------
 
 LOCAL MACHINE  ~
@@ -145,7 +145,7 @@ changing the value.
         ssh_binary = "ssh", -- Binary to use for running SSH command
         scp_binary = "scp", -- Binary to use for running SSH copy commands
         ssh_config_file_paths = { "$HOME/.ssh/config" }, -- Which files should be considered to contain the ssh host configurations. NOTE: `Include` is respected in the provided files.
-    
+
         -- These are useful for password-based SSH authentication.
         -- It provides parsing pattern for the plugin to detect that an input is requested.
         -- Each element contains the following attributes:
@@ -169,7 +169,7 @@ changing the value.
           },
         },
       },
-    
+
       -- Path to the script that would be copied to the remote and called to ensure that neovim gets installed.
       -- Default path is to the plugin's own ./scripts/neovim_install.sh file.
       neovim_install_script_path = utils.path_join(
@@ -178,15 +178,15 @@ changing the value.
         "scripts",
         "neovim_install.sh"
       ),
-    
+
       -- Modify the UI for the plugin's progress viewer.
       -- type can be "split" or "popup". All options from https://github.com/MunifTanjim/nui.nvim/tree/main/lua/nui/popup and https://github.com/MunifTanjim/nui.nvim/tree/main/lua/nui/split are supported.
       -- Note that some options like "border" are only available for "popup".
       progress_view = {
         type = "popup",
       },
-    
-    
+
+
       -- Offline mode configuration. For more details, see the "Offline mode" section below.
       offline_mode = {
         -- Should offline mode be enabled?
@@ -196,7 +196,7 @@ changing the value.
         -- What path should be looked at to find locally available releases
         cache_dir = utils.path_join(utils.is_windows, vim.fn.stdpath("cache"), constants.PLUGIN_NAME, "version_cache"),
       },
-    
+
       -- Remote configuration
       remote = {
         -- List of directories that should be copied over
@@ -237,7 +237,7 @@ changing the value.
           },
         },
       },
-    
+
       -- You can supply your own callback that should be called to create the local client. This is the default implementation.
       -- Two arguments are passed to the callback:
       -- port: Local port at which the remote server is available
@@ -250,7 +250,7 @@ changing the value.
           end
         end)
       end,
-    
+
       -- Plugin log related configuration [PREFER NOT TO CHANGE THIS]
       log = {
         -- Where is the log file
@@ -397,12 +397,14 @@ system. Alternatively, you can also clone the repo at a separate location and
 run this script from inside the cloned repo.
 
 >bash
-    ./scripts/neovim_download.sh -v <version> -d <cache-dir> -o <os-type>
-    
+    ./scripts/neovim_download.sh -v <version> -d <cache-dir> -o <os-type> -a <arch-type> -t <release-type>
+
      <version> can be stable, nightly or any Neovim release provided like v0.9.4
      <cache-dir> is the path in which the Neovim release and it's checksum should be downloaded. This should be same as the cache_dir plugin configuration value else it won't be
      detected by the plugin. See configuration below.
      <os-type> specifies which OS's binaries should be downloaded. Supported values are "Linux" and "macOS"
+     <arch-type> is the host's architecture. Can be `x86_64` or `arm64`
+     <release-type> is type of release to download. Can be `binary` or `source`
 <
 
 To enable this,

--- a/tests/remote-nvim/providers/provider_spec.lua
+++ b/tests/remote-nvim/providers/provider_spec.lua
@@ -11,6 +11,7 @@ describe("Provider", function()
   local provider
   local provider_host
   local remote_nvim_config_copy
+  assert:set_parameter("TableFormatLevel", 1)
 
   before_each(function()
     provider_host = require("remote-nvim.utils").generate_random_string(6)
@@ -65,7 +66,7 @@ describe("Provider", function()
   end)
 
   describe("should handle setting workspace variables", function()
-    local detect_remote_os_stub, get_remote_neovim_version_preference_stub
+    local detect_remote_os_and_arch_stub, get_remote_neovim_version_preference_stub
     local workspace_id = require("remote-nvim.utils").generate_random_string(10)
 
     before_each(function()
@@ -74,7 +75,7 @@ describe("Provider", function()
         conn_opts = { "-p", "3011" },
         progress_view = mock(require("remote-nvim.ui.progressview"), true),
       })
-      detect_remote_os_stub = stub(provider, "_get_remote_os")
+      detect_remote_os_and_arch_stub = stub(provider, "_get_remote_os_and_arch")
       get_remote_neovim_version_preference_stub = stub(provider, "_get_remote_neovim_version_preference")
 
       provider._config_provider:add_workspace_config(provider.unique_host_id, {
@@ -87,8 +88,10 @@ describe("Provider", function()
         workspace_id = workspace_id,
         neovim_version = "stable",
         os = "Linux",
+        arch = "x86_64",
+        neovim_install_method = "binary",
       })
-      detect_remote_os_stub.returns("Linux")
+      detect_remote_os_and_arch_stub.returns("Linux", "x86_64")
       get_remote_neovim_version_preference_stub.returns("stable")
       provider:_setup_workspace_variables()
     end)
@@ -104,6 +107,8 @@ describe("Provider", function()
       assert.are.same({
         provider = "local",
         host = provider.host,
+        arch = "x86_64",
+        neovim_install_method = "binary",
         connection_options = provider.conn_opts,
         remote_neovim_home = provider._remote_neovim_home,
         config_copy = nil,
@@ -331,6 +336,8 @@ describe("Provider", function()
         workspace_id = "ajdfkafd",
         neovim_version = "stable",
         os = "Linux",
+        arch = "x86_64",
+        neovim_install_method = "binary",
       })
       provider._local_path_to_remote_neovim_config = {}
     end)
@@ -402,6 +409,8 @@ describe("Provider", function()
         workspace_id = "ajdfkafd",
         neovim_version = "stable",
         os = "Linux",
+        arch = "x86_64",
+        neovim_install_method = "binary",
       })
       provider:_setup_workspace_variables()
     end)
@@ -544,6 +553,8 @@ describe("Provider", function()
           workspace_id = "akfdjakjfdk",
           neovim_version = "stable",
           os = "Linux",
+          arch = "x86_64",
+          neovim_install_method = "binary",
         })
         provider:_setup_workspace_variables()
       end)
@@ -576,7 +587,7 @@ describe("Provider", function()
         -- install neovim if needed
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64",
           match.is_string()
         )
 
@@ -633,7 +644,7 @@ describe("Provider", function()
 
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -o",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
           match.is_string()
         )
       end)
@@ -645,7 +656,7 @@ describe("Provider", function()
         provider:_setup_remote()
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          ("%s/scripts/neovim_download.sh -o Linux -v stable -d %s"):format(
+          ("%s/scripts/neovim_download.sh -o Linux -v stable -a x86_64 -t binary -d %s"):format(
             require("remote-nvim.utils").get_plugin_root(),
             remote_nvim.config.offline_mode.cache_dir
           ),
@@ -657,7 +668,7 @@ describe("Provider", function()
 
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -o",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
           match.is_string()
         )
       end)
@@ -732,6 +743,8 @@ describe("Provider", function()
         workspace_id = "ajfdalfj",
         neovim_version = "stable",
         os = "Linux",
+        arch = "x86_64",
+        neovim_install_method = "binary",
       })
       provider:_setup_workspace_variables()
     end)
@@ -812,6 +825,8 @@ describe("Provider", function()
         workspace_id = "ajdfkafd",
         neovim_version = "stable",
         os = "Linux",
+        arch = "x86_64",
+        neovim_install_method = "binary",
       })
     end)
 
@@ -878,6 +893,8 @@ describe("Provider", function()
         workspace_id = "ajdfkafd",
         neovim_version = "stable",
         os = "Linux",
+        arch = "x86_64",
+        neovim_install_method = "binary",
       })
     end)
 

--- a/tests/remote-nvim/providers/utils_spec.lua
+++ b/tests/remote-nvim/providers/utils_spec.lua
@@ -66,15 +66,66 @@ describe("Greater version finder should", function()
 end)
 
 describe("Offline revision names are correct", function()
+  it("for source release", function()
+    assert.equals(
+      "nvim-stable-source.tar.gz",
+      utils.get_offline_neovim_release_name("Linux", "stable", "x86_64", "source")
+    )
+    assert.equals(
+      "nvim-nightly-source.tar.gz",
+      utils.get_offline_neovim_release_name("Linux", "nightly", "x86_64", "source")
+    )
+    assert.equals(
+      "nvim-v0.9.5-source.tar.gz",
+      utils.get_offline_neovim_release_name("macOS", "v0.9.5", "x86_64", "source")
+    )
+  end)
+
   it("for macOS", function()
-    assert.equals("nvim-stable-macos.tar.gz", utils.get_offline_neovim_release_name("macOS", "stable"))
-    assert.equals("nvim-nightly-macos.tar.gz", utils.get_offline_neovim_release_name("macOS", "nightly"))
-    assert.equals("nvim-v0.9.5-macos.tar.gz", utils.get_offline_neovim_release_name("macOS", "v0.9.5"))
+    assert.equals(
+      "nvim-stable-macos.tar.gz",
+      utils.get_offline_neovim_release_name("macOS", "stable", "x86_64", "binary")
+    )
+    assert.equals(
+      "nvim-nightly-macos-x86_64.tar.gz",
+      utils.get_offline_neovim_release_name("macOS", "nightly", "x86_64", "binary")
+    )
+    assert.equals(
+      "nvim-v0.9.5-macos.tar.gz",
+      utils.get_offline_neovim_release_name("macOS", "v0.9.5", "x86_64", "binary")
+    )
+    assert.equals(
+      "nvim-v0.10.1-macos-arm64.tar.gz",
+      utils.get_offline_neovim_release_name("macOS", "v0.10.1", "arm64", "binary")
+    )
   end)
 
   it("for Linux", function()
-    assert.equals("nvim-stable-linux.appimage", utils.get_offline_neovim_release_name("Linux", "stable"))
-    assert.equals("nvim-nightly-linux.appimage", utils.get_offline_neovim_release_name("Linux", "nightly"))
-    assert.equals("nvim-v0.9.5-linux.appimage", utils.get_offline_neovim_release_name("Linux", "v0.9.5"))
+    assert.equals(
+      "nvim-stable-linux.appimage",
+      utils.get_offline_neovim_release_name("Linux", "stable", "x86_64", "binary")
+    )
+    assert.equals(
+      "nvim-nightly-linux.appimage",
+      utils.get_offline_neovim_release_name("Linux", "nightly", "x86_64", "binary")
+    )
+    assert.equals(
+      "nvim-v0.9.5-linux.appimage",
+      utils.get_offline_neovim_release_name("Linux", "v0.9.5", "x86_64", "binary")
+    )
+  end)
+end)
+
+describe("Binary release is available for", function()
+  it("macOS and Windows", function()
+    assert.is_true(utils.is_binary_release_available("macOS", "anything_goes"))
+    assert.is_true(utils.is_binary_release_available("Windows", "anything_goes"))
+  end)
+
+  it("Linux but not for RISC and ARM", function()
+    assert.is_true(utils.is_binary_release_available("Linux", "x86_64"))
+    assert.is_false(utils.is_binary_release_available("Linux", "arm64"))
+    assert.is_false(utils.is_binary_release_available("Linux", "armv7l"))
+    assert.is_false(utils.is_binary_release_available("Linux", "riscv64"))
   end)
 end)


### PR DESCRIPTION
For some systems, Neovim binaries are not available. So, it is important to provide alternatives for such platforms. These alternatives are:
1. Building Neovim from source
2. Symlinking to existing Neovim binary present on the remote

This allows the user to use alternatives while those binaries are not available.