### PR TITLE
Fixing correct syntax for checkealth

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you use any other plugin manager, ensure that you call `require("remote-nvim"
 
 > [!NOTE]
 >
-> Run `:checkhealth remote-nvim.nvim` to ensure necesssary binaries are available. If missing,
+> Run `:checkhealth remote-nvim` to ensure necesssary binaries are available. If missing,
 > parts of the plugin might be broken.
 
 ## ⚙️ Advanced configuration


### PR DESCRIPTION
The syntax in the README to check the health of the plugin is wrong, it results

```
remote-nvim/nvim: 

- ERROR No healthcheck found for "remote-nvim/nvim" plugin.
```

Removing the `.nvim` at the end makes it work