### PR TITLE
fix(scripts): Explicitly specify bash command to run scripts

### DIFF
--- a/lua/remote-nvim/providers/provider.lua
+++ b/lua/remote-nvim/providers/provider.lua
@@ -588,7 +588,7 @@ function Provider:_setup_remote()
     end
 
     -- Set correct permissions and install Neovim
-    local install_neovim_cmd = ([[chmod +x %s && chmod +x %s && chmod +x %s && %s -v %s -d %s -m %s -a %s]]):format(
+    local install_neovim_cmd = ([[chmod +x %s && chmod +x %s && chmod +x %s && bash %s -v %s -d %s -m %s -a %s]]):format(
       self._remote_neovim_download_script_path,
       self._remote_neovim_utils_script_path,
       self._remote_neovim_install_script_path,
@@ -603,7 +603,7 @@ function Provider:_setup_remote()
       -- We need to ensure that we download Neovim version locally and then push it to the remote
       if not remote_nvim.config.offline_mode.no_github then
         self:run_command(
-          ("%s -o %s -v %s -a %s -t %s -d %s"):format(
+          ("bash %s -o %s -v %s -a %s -t %s -d %s"):format(
             utils.path_join(utils.is_windows, utils.get_plugin_root(), "scripts", "neovim_download.sh"),
             self._remote_os,
             self._remote_neovim_version,

--- a/tests/remote-nvim/providers/provider_spec.lua
+++ b/tests/remote-nvim/providers/provider_spec.lua
@@ -636,7 +636,7 @@ describe("Provider", function()
         -- install neovim if needed
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64",
           match.is_string()
         )
 
@@ -695,7 +695,7 @@ describe("Provider", function()
 
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
           match.is_string()
         )
       end)
@@ -707,7 +707,7 @@ describe("Provider", function()
         provider:_setup_remote()
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          ("%s/scripts/neovim_download.sh -o Linux -v stable -a x86_64 -t binary -d %s"):format(
+          ("bash %s/scripts/neovim_download.sh -o Linux -v stable -a x86_64 -t binary -d %s"):format(
             require("remote-nvim.utils").get_plugin_root(),
             remote_nvim.config.offline_mode.cache_dir
           ),
@@ -719,7 +719,7 @@ describe("Provider", function()
 
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
           match.is_string()
         )
       end)


### PR DESCRIPTION
Nix-based systems mess up the interpreter path to make it useless when it gets copied over to the remote system. So, instead now, we manually specify the shell to execute it under. So far, I cannot think of any drawbacks of using this except the need to be explicit which is honestly not a bad thing. We'll see how this pans out though.