### PR TITLE
Fix #157: Correct single quote escaping for POSIX shells

### DIFF
--- a/lua/remote-nvim/providers/provider.lua
+++ b/lua/remote-nvim/providers/provider.lua
@@ -139,7 +139,7 @@ end
 function Provider:_setup_workspace_variables()
   if vim.tbl_isempty(self._config_provider:get_workspace_config(self.unique_host_id)) then
     self.logger.debug("Did not find any existing configuration. Creating one now..")
-    self:run_command("echo 'Hello'", "Testing remote connection")
+    self:run_command('echo "Hello"', "Testing remote connection")
     self._config_provider:add_workspace_config(self.unique_host_id, {
       provider = self.provider_type,
       host = self.host,


### PR DESCRIPTION
Fixed an issue with `run_command("echo 'Hello'")` where wrapping commands in args in single quotes caused invalid parsing in POSIX-compliant shells. In these shells, single quotes enclose literal text, making escape sequences like `\'` invalid. For more details, refer to the GNU Bash manual: https://www.gnu.org/software/bash/manual/html_node/Single-Quotes.html.

For example, calling `run_command("echo 'Hello'")` would be incorrectly escaped by `vim.fn.shellescape` as `echo '\''Hello'\''`, leading to invalid parsing. The fix replaces the outer double quotes with single quotes where necessary and command arg with double qoute, ensuring proper escaping and compatibility across different shell environments.