### PR TITLE
Copy local plugin directory to remote

### DIFF
--- a/lua/remote-nvim/init.lua
+++ b/lua/remote-nvim/init.lua
@@ -71,6 +71,7 @@ local utils = require("remote-nvim.utils")
 ---@field data remote-nvim.config.PluginConfig.Remote.CopyDirs.FolderStructure Directory to copy over into remote XDG_DATA_HOME/nvim. Default is nothing. If base is not specified, it is assumed to be :lua= vim.fn.stdpath("data")
 ---@field state remote-nvim.config.PluginConfig.Remote.CopyDirs.FolderStructure Directory to copy over into remote XDG_STATE_HOME/nvim. Default is nothing. If base is not specified, it is assumed to be :lua= vim.fn.stdpath("state")
 ---@field cache remote-nvim.config.PluginConfig.Remote.CopyDirs.FolderStructure Directory to copy over into remote XDG_CACHE_HOME/nvim. Default is nothing. If base is not specified, it is assumed to be :lua= vim.fn.stdpath("cache")
+---@field local_plugins remote-nvim.config.PluginConfig.Remote.CopyDirs.FolderStructure Directory to copy over into remote XDG_CACHE_HOME/nvim. Default is nothing. If base is not specified, it is assumed to be :lua= vim.fn.stdpath("config")
 
 ---@class remote-nvim.config.PluginConfig.Remote
 ---@field copy_dirs remote-nvim.config.PluginConfig.Remote.CopyDirs Which directories should be copied over to the remote

--- a/lua/remote-nvim/providers/ssh/ssh_executor.lua
+++ b/lua/remote-nvim/providers/ssh/ssh_executor.lua
@@ -46,6 +46,10 @@ function SSHExecutor:upload(localSrcPath, remoteDestPath, job_opts)
   job_opts = job_opts or {}
   job_opts.compression = job_opts.compression or {}
 
+  -- Ensure that destination folder exists
+  local mkdir_ssh_command = self:_build_run_command(("mkdir -p %s"):format(remoteDestPath), job_opts)
+  self:run_executor_job(mkdir_ssh_command, job_opts)
+
   if job_opts.compression.enabled or false then
     local paths = vim.split(localSrcPath, " ")
     local parent_dir, subdirs = utils.find_common_parent(paths)


### PR DESCRIPTION
I recently got into trying out plugin development for neovim in order to improve my workflow.
To do so I use a local plugins folder that is then used by `lazy.nvim` instead of pulling from github. In order to be able to use these plugins in remote environments, I thus need to copy them over onto the remote, and have `lazy.nvim` correctly configure the path there.

Thus:
- This PR handles the copying of a 'local plugin' folder onto the remote
```lua
    copy_dirs = {
      local_plugins = {
        base = "/home/arnaud/devel/nvim",
        dirs = "*",
        compression = {
          enabled = true,
        },
      },
```
- I then configure `lazy.nvim` as follows to use the proper path on the remote.
```lua
local lazy_config = {
  dev = {
    -- Directory where you store your local plugin projects. If a function is used,
    -- the plugin directory (e.g. `~/projects/plugin-name`) must be returned.
    path = function(plugin)
      if vim.g.remote_neovim_host then
        return vim.fn.stdpath('config') .. '/../local_plugins/nvim/' .. plugin.name
      else
        return "~/devel/nvim/" .. plugin.name
      end
    end,
}
```
- Added bonus, I've added the variable `vim.g.remote_neovim_unique_host_id` to store the name of the running container, which can then be displayed when running any neovim instance connected to the remote. This is helpful when using multiple containers simultaneously to keep track of them.
For example for 'mini.nvim'
```lua
    -- You can configure sections in the statusline by overriding their
    -- default behavior. For example, here we replace the section for
    -- cursor information with codeium status instead (it appears on the furthest right of the statusline).
    ---@diagnostic disable-next-line: duplicate-set-field
    statusline.section_location = function()
      local value = ''
      local codeium = require('codeium.virtual_text').status_string()
      value = value .. codeium

      -- check if this is an nvim-remote instance
      if vim.g.remote_neovim_host then
        local remote_name = (" | Remote: %s"):format(vim.g.remote_neovim_unique_host_id) or ""
        value = value .. remote_name
      end

      return value
    end
```

Retrospectively it might have been better to implement a mechanism to copy any directory onto the remote, not just something specific to the local plugins.

What do you think?
