### PR TITLE
Fix pty for handling devpod provider setup

### DIFF
--- a/lua/remote-nvim/providers/devpod/devpod_provider.lua
+++ b/lua/remote-nvim/providers/devpod/devpod_provider.lua
@@ -158,7 +158,11 @@ function DevpodProvider:_handle_provider_setup()
   if self._devpod_provider then
     self.local_provider:run_command(
       ("%s provider list --output json"):format(remote_nvim.config.devpod.binary),
-      ("Checking if the %s provider is present"):format(self._devpod_provider)
+      ("Checking if the %s provider is present"):format(self._devpod_provider),
+      nil,
+      nil,
+      false,
+      false
     )
     local stdout = self.local_provider.executor:job_stdout()
     local provider_list_output = vim.json.decode(vim.tbl_isempty(stdout) and "{}" or table.concat(stdout, "\n"))

--- a/lua/remote-nvim/providers/executor.lua
+++ b/lua/remote-nvim/providers/executor.lua
@@ -11,6 +11,7 @@ local Executor = require("remote-nvim.middleclass")("Executor")
 ---@field additional_opts? string[] Additional options to pass to the `tar` command. See `man tar` for possible options
 
 ---@class remote-nvim.provider.Executor.JobOpts
+---@field pty boolean? Whether to set pty option
 ---@field additional_conn_opts string? Connection options
 ---@field stdout_cb function? Standard output callback
 ---@field exit_cb function? On exit callback
@@ -76,7 +77,7 @@ function Executor:run_executor_job(command, job_opts)
 
   self:reset() -- Reset job internal state variables
   self._job_id = vim.fn.jobstart(command, {
-    pty = true,
+    pty = job_opts.pty == nil or job_opts.pty,
     on_stdout = function(_, data_chunk)
       self:process_stdout(data_chunk, job_opts.stdout_cb)
     end,

--- a/lua/remote-nvim/providers/provider.lua
+++ b/lua/remote-nvim/providers/provider.lua
@@ -991,7 +991,8 @@ end
 ---@param extra_opts string? Extra options to pass to the underlying command
 ---@param exit_cb function? Exit callback to execute
 ---@param on_local_executor boolean? Should run this command on the local executor
-function Provider:run_command(command, desc, extra_opts, exit_cb, on_local_executor)
+---@param pty boolean? Whether to use pty or not
+function Provider:run_command(command, desc, extra_opts, exit_cb, on_local_executor, pty)
   self.logger.fmt_debug("[%s][%s] Running %s", self.provider_type, self.unique_host_id, command)
   on_local_executor = on_local_executor or false
   local executor = on_local_executor and self.local_executor or self.executor
@@ -1008,6 +1009,7 @@ function Provider:run_command(command, desc, extra_opts, exit_cb, on_local_execu
     exit_cb = exit_cb(section_node)
   end
   executor:run_command(command, {
+    pty = pty == nil or pty,
     additional_conn_opts = extra_opts,
     exit_cb = exit_cb,
     stdout_cb = self:_get_stdout_fn_for_node(section_node),


### PR DESCRIPTION
Implementation of this comment: https://github.com/amitds1997/remote-nvim.nvim/issues/182#issuecomment-2543545249, adding `pty` as an argument to the provider executor and passing `pty = false` when handling the provider setup for devpod.

I was unfortunately not able to set up all pre-commit hooks, so the `selene` hook has not been run against this PR.

This should fix #182.