### PR TITLE
fix: correct neovim utils script path reference

### DIFF
--- a/lua/remote-nvim/providers/provider.lua
+++ b/lua/remote-nvim/providers/provider.lua
@@ -215,7 +215,7 @@ function Provider:_setup_workspace_variables()
   self._remote_neovim_download_script_path =
     utils.path_join(self._remote_is_windows, self._remote_scripts_path, "neovim_download.sh")
   self._remote_neovim_utils_script_path =
-    utils.path_join(self._remote_is_windows, self._remote_scripts_path, "neovim_utils.sh")
+    utils.path_join(self._remote_is_windows, self._remote_scripts_path, "utils/neovim.sh")
   self._remote_workspace_id_path =
     utils.path_join(self._remote_is_windows, self._remote_workspaces_path, self._remote_workspace_id)
 

--- a/tests/remote-nvim/providers/provider_spec.lua
+++ b/tests/remote-nvim/providers/provider_spec.lua
@@ -171,7 +171,7 @@ describe("Provider", function()
       assert.equals(("%s/scripts"):format(remote_home), provider._remote_scripts_path)
       assert.equals(("%s/scripts/neovim_install.sh"):format(remote_home), provider._remote_neovim_install_script_path)
       assert.equals(("%s/scripts/neovim_download.sh"):format(remote_home), provider._remote_neovim_download_script_path)
-      assert.equals(("%s/scripts/neovim_utils.sh"):format(remote_home), provider._remote_neovim_utils_script_path)
+      assert.equals(("%s/scripts/utils/neovim.sh"):format(remote_home), provider._remote_neovim_utils_script_path)
       assert.equals(("%s/workspaces/%s"):format(remote_home, workspace_id), provider._remote_workspace_id_path)
 
       -- XDG variables
@@ -636,7 +636,7 @@ describe("Provider", function()
         -- install neovim if needed
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/utils/neovim.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64",
           match.is_string()
         )
 
@@ -695,7 +695,7 @@ describe("Provider", function()
 
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/utils/neovim.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
           match.is_string()
         )
       end)
@@ -719,7 +719,7 @@ describe("Provider", function()
 
         assert.stub(run_command_stub).was.called_with(
           match.is_ref(provider),
-          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/neovim_utils.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
+          "chmod +x ~/.remote-nvim/scripts/neovim_download.sh && chmod +x ~/.remote-nvim/scripts/utils/neovim.sh && chmod +x ~/.remote-nvim/scripts/neovim_install.sh && bash ~/.remote-nvim/scripts/neovim_install.sh -v stable -d ~/.remote-nvim -m binary -a x86_64 -o",
           match.is_string()
         )
       end)


### PR DESCRIPTION
Fix #220

Change incorrect reference from 'neovim_utils.sh' to 'utils/neovim.sh'. The wrong path was causing chmod failures during remote neovim installation.

Updates provider code and corresponding tests.